### PR TITLE
eop response rate info

### DIFF
--- a/Methods.qmd
+++ b/Methods.qmd
@@ -39,6 +39,111 @@ The following methods were performed for collecting data during the statewide st
 
 ::::
 
+<style type="text/css">
+  .tg  {border-collapse:collapse;border-spacing:0;}
+.tg td{border-style:solid;border-width:1px;font-family:Arial, sans-serif;font-size:14px;overflow:hidden;
+  padding:10px 5px;word-break:normal;}
+.tg th{border-style:solid;border-width:1px;font-family:Arial, sans-serif;font-size:14px;font-weight:normal;
+  overflow:hidden;padding:10px 5px;word-break:normal;}
+.tg .tg-9d8n{border-color:inherit;font-size:22px;text-align:center;vertical-align:top}
+.tg .tg-0pky{border-color:inherit;text-align:left;vertical-align:top}
+</style>
+  
+  <table class="tg" border="1">
+  <thead>
+  <tr>
+  <th class="tg-9d8n" colspan="4"><span style="font-weight:bold">EOP Response Rate by Campus</span></th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr>
+  <td class="tg-0pky"><strong>Campus</strong></td>
+  <td class="tg-0pky"><strong>Emails Sent</strong></td>
+  <td class="tg-0pky"><strong>Survey Responses</strong></td>
+  <td class="tg-0pky"><strong>Response Rate</strong></td>
+  </tr>
+  <tr>
+  <td class="tg-0pky">Allan Hancock CC</td>
+  <td class="tg-0pky">858</td>
+  <td class="tg-0pky">112</td>
+  <td class="tg-0pky">13.1%</td>
+  </tr>
+  <tr>
+  <td class="tg-0pky">Butte CC</td>
+  <td class="tg-0pky">387</td>
+  <td class="tg-0pky">132</td>
+  <td class="tg-0pky">34.1%</td>
+  </tr>
+  <tr>
+  <td class="tg-0pky">Clovis CC</td>
+  <td class="tg-0pky">481</td>
+  <td class="tg-0pky">140</td>
+  <td class="tg-0pky">29.1%</td>
+  </tr>
+  <tr>
+  <td class="tg-0pky">Palo Verde CC</td>
+  <td class="tg-0pky">159</td>
+  <td class="tg-0pky">36</td>
+  <td class="tg-0pky">22.6%</td>
+  </tr>
+  <tr>
+  <td class="tg-0pky">Mt. Sac CC</td>
+  <td class="tg-0pky">1,129</td>
+  <td class="tg-0pky">270</td>
+  <td class="tg-0pky">23.9%</td>
+  </tr>
+  <tr>
+  <td class="tg-0pky">CSU Bakersfield</td>
+  <td class="tg-0pky">702</td>
+  <td class="tg-0pky">114</td>
+  <td class="tg-0pky">16.2%</td>
+  </tr>
+  <tr>
+  <td class="tg-0pky">CSU Dominguez Hills</td>
+  <td class="tg-0pky">1,764</td>
+  <td class="tg-0pky">58</td>
+  <td class="tg-0pky">3.3%</td>
+  </tr>
+  <tr>
+  <td class="tg-0pky">Cal State LA</td>
+  <td class="tg-0pky">2,663</td>
+  <td class="tg-0pky">343</td>
+  <td class="tg-0pky">12.9%</td>
+  </tr>
+  <tr>
+  <td class="tg-0pky">Cal State San Bernadino</td>
+  <td class="tg-0pky">1,135</td>
+  <td class="tg-0pky">191</td>
+  <td class="tg-0pky">16.8%</td>
+  </tr>
+  <tr>
+  <td class="tg-0pky">Sacramento State</td>
+  <td class="tg-0pky">1,229</td>
+  <td class="tg-0pky">253</td>
+  <td class="tg-0pky">20.1%</td>
+  </tr>
+  <tr>
+  <td class="tg-0pky">San Francisco State</td>
+  <td class="tg-0pky">2,743</td>
+  <td class="tg-0pky">279</td>
+  <td class="tg-0pky">10.2%</td>
+  </tr>
+  <tr>
+  <td class="tg-0pky">UC Berkley</td>
+  <td class="tg-0pky">600</td>
+  <td class="tg-0pky">182</td>
+  <td class="tg-0pky">30.3%</td>
+  </tr>
+  <tr>
+  <td class="tg-0pky"><span style="font-weight:bold">Total</span></td>
+  <td class="tg-0pky"><span style="font-weight:bold">13,850</span></td>
+  <td class="tg-0pky"><span style="font-weight:bold">2,110</span></td>
+  <td class="tg-0pky"><span style="font-weight:bold">15.2%</span></td>
+  </tr>
+  </tbody></table border="1">
+  
+  <br>
+
 ![](automated_process.png)
 
 <br>

--- a/Methods.qmd
+++ b/Methods.qmd
@@ -46,7 +46,8 @@ The following methods were performed for collecting data during the statewide st
 .tg th{border-style:solid;border-width:1px;font-family:Arial, sans-serif;font-size:14px;font-weight:normal;
   overflow:hidden;padding:10px 5px;word-break:normal;}
 .tg .tg-9d8n{border-color:inherit;font-size:22px;text-align:center;vertical-align:top}
-.tg .tg-0pky{border-color:inherit;text-align:left;vertical-align:top}
+.tg .tg-0pky{border-color:inherit;text-align:center;vertical-align:top}
+.tg .tg-left{border-color:inherit;text-align:left;vertical-align:top;}
 </style>
   
   <table class="tg" border="1">
@@ -57,85 +58,85 @@ The following methods were performed for collecting data during the statewide st
   </thead>
   <tbody>
   <tr>
-  <td class="tg-0pky"><strong>Campus</strong></td>
-  <td class="tg-0pky"><strong>Emails Sent</strong></td>
-  <td class="tg-0pky"><strong>Survey Responses</strong></td>
-  <td class="tg-0pky"><strong>Response Rate</strong></td>
+  <td class="tg-left"><strong>Campus</strong></td>
+  <td class="tg-0pky"><strong>Population size</strong></td>
+  <td class="tg-0pky"><strong>Number of responses</strong></td>
+  <td class="tg-0pky"><strong>Response rate</strong></td>
   </tr>
   <tr>
-  <td class="tg-0pky">Allan Hancock CC</td>
+  <td class="tg-left">Allan Hancock CC</td>
   <td class="tg-0pky">858</td>
   <td class="tg-0pky">112</td>
   <td class="tg-0pky">13.1%</td>
   </tr>
   <tr>
-  <td class="tg-0pky">Butte CC</td>
+  <td class="tg-left">Butte CC</td>
   <td class="tg-0pky">387</td>
   <td class="tg-0pky">132</td>
   <td class="tg-0pky">34.1%</td>
   </tr>
   <tr>
-  <td class="tg-0pky">Clovis CC</td>
+  <td class="tg-left">Clovis CC</td>
   <td class="tg-0pky">481</td>
   <td class="tg-0pky">140</td>
   <td class="tg-0pky">29.1%</td>
   </tr>
   <tr>
-  <td class="tg-0pky">Palo Verde CC</td>
+  <td class="tg-left">Palo Verde CC</td>
   <td class="tg-0pky">159</td>
   <td class="tg-0pky">36</td>
   <td class="tg-0pky">22.6%</td>
   </tr>
   <tr>
-  <td class="tg-0pky">Mt. Sac CC</td>
+  <td class="tg-left">Mt. Sac CC</td>
   <td class="tg-0pky">1,129</td>
   <td class="tg-0pky">270</td>
   <td class="tg-0pky">23.9%</td>
   </tr>
   <tr>
-  <td class="tg-0pky">CSU Bakersfield</td>
+  <td class="tg-left">CSU Bakersfield</td>
   <td class="tg-0pky">702</td>
   <td class="tg-0pky">114</td>
   <td class="tg-0pky">16.2%</td>
   </tr>
   <tr>
-  <td class="tg-0pky">CSU Dominguez Hills</td>
+  <td class="tg-left">CSU Dominguez Hills</td>
   <td class="tg-0pky">1,764</td>
   <td class="tg-0pky">58</td>
   <td class="tg-0pky">3.3%</td>
   </tr>
   <tr>
-  <td class="tg-0pky">Cal State LA</td>
+  <td class="tg-left">Cal State LA</td>
   <td class="tg-0pky">2,663</td>
   <td class="tg-0pky">343</td>
   <td class="tg-0pky">12.9%</td>
   </tr>
   <tr>
-  <td class="tg-0pky">Cal State San Bernadino</td>
+  <td class="tg-left">Cal State San Bernadino</td>
   <td class="tg-0pky">1,135</td>
   <td class="tg-0pky">191</td>
   <td class="tg-0pky">16.8%</td>
   </tr>
   <tr>
-  <td class="tg-0pky">Sacramento State</td>
+  <td class="tg-left">Sacramento State</td>
   <td class="tg-0pky">1,229</td>
   <td class="tg-0pky">253</td>
   <td class="tg-0pky">20.1%</td>
   </tr>
   <tr>
-  <td class="tg-0pky">San Francisco State</td>
+  <td class="tg-left">San Francisco State</td>
   <td class="tg-0pky">2,743</td>
   <td class="tg-0pky">279</td>
   <td class="tg-0pky">10.2%</td>
   </tr>
   <tr>
-  <td class="tg-0pky">UC Berkley</td>
+  <td class="tg-left">UC Berkley</td>
   <td class="tg-0pky">600</td>
   <td class="tg-0pky">182</td>
   <td class="tg-0pky">30.3%</td>
   </tr>
   <tr>
-  <td class="tg-0pky"><span style="font-weight:bold">Total</span></td>
+  <td class="tg-left"><span style="font-weight:bold">Total</span></td>
   <td class="tg-0pky"><span style="font-weight:bold">13,850</span></td>
   <td class="tg-0pky"><span style="font-weight:bold">2,110</span></td>
   <td class="tg-0pky"><span style="font-weight:bold">15.2%</span></td>

--- a/docs/Methods.html
+++ b/docs/Methods.html
@@ -220,7 +220,8 @@ ul.task-list li input[type="checkbox"] {
 .tg th{border-style:solid;border-width:1px;font-family:Arial, sans-serif;font-size:14px;font-weight:normal;
   overflow:hidden;padding:10px 5px;word-break:normal;}
 .tg .tg-9d8n{border-color:inherit;font-size:22px;text-align:center;vertical-align:top}
-.tg .tg-0pky{border-color:inherit;text-align:left;vertical-align:top}
+.tg .tg-0pky{border-color:inherit;text-align:center;vertical-align:top}
+.tg .tg-left{border-color:inherit;text-align:left;vertical-align:top;}
 </style>
 <table class="tg" border="1">
 <thead>
@@ -232,21 +233,21 @@ ul.task-list li input[type="checkbox"] {
 </thead>
 <tbody>
 <tr>
-<td class="tg-0pky">
+<td class="tg-left">
 <strong>Campus</strong>
 </td>
 <td class="tg-0pky">
-<strong>Emails Sent</strong>
+<strong>Population size</strong>
 </td>
 <td class="tg-0pky">
-<strong>Survey Responses</strong>
+<strong>Number of responses</strong>
 </td>
 <td class="tg-0pky">
-<strong>Response Rate</strong>
+<strong>Response rate</strong>
 </td>
 </tr>
 <tr>
-<td class="tg-0pky">
+<td class="tg-left">
 Allan Hancock CC
 </td>
 <td class="tg-0pky">
@@ -260,7 +261,7 @@ Allan Hancock CC
 </td>
 </tr>
 <tr>
-<td class="tg-0pky">
+<td class="tg-left">
 Butte CC
 </td>
 <td class="tg-0pky">
@@ -274,7 +275,7 @@ Butte CC
 </td>
 </tr>
 <tr>
-<td class="tg-0pky">
+<td class="tg-left">
 Clovis CC
 </td>
 <td class="tg-0pky">
@@ -288,7 +289,7 @@ Clovis CC
 </td>
 </tr>
 <tr>
-<td class="tg-0pky">
+<td class="tg-left">
 Palo Verde CC
 </td>
 <td class="tg-0pky">
@@ -302,7 +303,7 @@ Palo Verde CC
 </td>
 </tr>
 <tr>
-<td class="tg-0pky">
+<td class="tg-left">
 Mt. Sac CC
 </td>
 <td class="tg-0pky">
@@ -316,7 +317,7 @@ Mt. Sac CC
 </td>
 </tr>
 <tr>
-<td class="tg-0pky">
+<td class="tg-left">
 CSU Bakersfield
 </td>
 <td class="tg-0pky">
@@ -330,7 +331,7 @@ CSU Bakersfield
 </td>
 </tr>
 <tr>
-<td class="tg-0pky">
+<td class="tg-left">
 CSU Dominguez Hills
 </td>
 <td class="tg-0pky">
@@ -344,7 +345,7 @@ CSU Dominguez Hills
 </td>
 </tr>
 <tr>
-<td class="tg-0pky">
+<td class="tg-left">
 Cal State LA
 </td>
 <td class="tg-0pky">
@@ -358,7 +359,7 @@ Cal State LA
 </td>
 </tr>
 <tr>
-<td class="tg-0pky">
+<td class="tg-left">
 Cal State San Bernadino
 </td>
 <td class="tg-0pky">
@@ -372,7 +373,7 @@ Cal State San Bernadino
 </td>
 </tr>
 <tr>
-<td class="tg-0pky">
+<td class="tg-left">
 Sacramento State
 </td>
 <td class="tg-0pky">
@@ -386,7 +387,7 @@ Sacramento State
 </td>
 </tr>
 <tr>
-<td class="tg-0pky">
+<td class="tg-left">
 San Francisco State
 </td>
 <td class="tg-0pky">
@@ -400,7 +401,7 @@ San Francisco State
 </td>
 </tr>
 <tr>
-<td class="tg-0pky">
+<td class="tg-left">
 UC Berkley
 </td>
 <td class="tg-0pky">
@@ -414,7 +415,7 @@ UC Berkley
 </td>
 </tr>
 <tr>
-<td class="tg-0pky">
+<td class="tg-left">
 <span style="font-weight:bold">Total</span>
 </td>
 <td class="tg-0pky">

--- a/docs/Methods.html
+++ b/docs/Methods.html
@@ -213,6 +213,223 @@ ul.task-list li input[type="checkbox"] {
 <p><img src="consort_diagram.png" class="img-fluid" style="width:100.0%"></p>
 </div>
 </div>
+<style type="text/css">
+  .tg  {border-collapse:collapse;border-spacing:0;}
+.tg td{border-style:solid;border-width:1px;font-family:Arial, sans-serif;font-size:14px;overflow:hidden;
+  padding:10px 5px;word-break:normal;}
+.tg th{border-style:solid;border-width:1px;font-family:Arial, sans-serif;font-size:14px;font-weight:normal;
+  overflow:hidden;padding:10px 5px;word-break:normal;}
+.tg .tg-9d8n{border-color:inherit;font-size:22px;text-align:center;vertical-align:top}
+.tg .tg-0pky{border-color:inherit;text-align:left;vertical-align:top}
+</style>
+<table class="tg" border="1">
+<thead>
+<tr>
+<th class="tg-9d8n" colspan="4">
+<span style="font-weight:bold">EOP Response Rate by Campus</span>
+</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tg-0pky">
+<strong>Campus</strong>
+</td>
+<td class="tg-0pky">
+<strong>Emails Sent</strong>
+</td>
+<td class="tg-0pky">
+<strong>Survey Responses</strong>
+</td>
+<td class="tg-0pky">
+<strong>Response Rate</strong>
+</td>
+</tr>
+<tr>
+<td class="tg-0pky">
+Allan Hancock CC
+</td>
+<td class="tg-0pky">
+858
+</td>
+<td class="tg-0pky">
+112
+</td>
+<td class="tg-0pky">
+13.1%
+</td>
+</tr>
+<tr>
+<td class="tg-0pky">
+Butte CC
+</td>
+<td class="tg-0pky">
+387
+</td>
+<td class="tg-0pky">
+132
+</td>
+<td class="tg-0pky">
+34.1%
+</td>
+</tr>
+<tr>
+<td class="tg-0pky">
+Clovis CC
+</td>
+<td class="tg-0pky">
+481
+</td>
+<td class="tg-0pky">
+140
+</td>
+<td class="tg-0pky">
+29.1%
+</td>
+</tr>
+<tr>
+<td class="tg-0pky">
+Palo Verde CC
+</td>
+<td class="tg-0pky">
+159
+</td>
+<td class="tg-0pky">
+36
+</td>
+<td class="tg-0pky">
+22.6%
+</td>
+</tr>
+<tr>
+<td class="tg-0pky">
+Mt. Sac CC
+</td>
+<td class="tg-0pky">
+1,129
+</td>
+<td class="tg-0pky">
+270
+</td>
+<td class="tg-0pky">
+23.9%
+</td>
+</tr>
+<tr>
+<td class="tg-0pky">
+CSU Bakersfield
+</td>
+<td class="tg-0pky">
+702
+</td>
+<td class="tg-0pky">
+114
+</td>
+<td class="tg-0pky">
+16.2%
+</td>
+</tr>
+<tr>
+<td class="tg-0pky">
+CSU Dominguez Hills
+</td>
+<td class="tg-0pky">
+1,764
+</td>
+<td class="tg-0pky">
+58
+</td>
+<td class="tg-0pky">
+3.3%
+</td>
+</tr>
+<tr>
+<td class="tg-0pky">
+Cal State LA
+</td>
+<td class="tg-0pky">
+2,663
+</td>
+<td class="tg-0pky">
+343
+</td>
+<td class="tg-0pky">
+12.9%
+</td>
+</tr>
+<tr>
+<td class="tg-0pky">
+Cal State San Bernadino
+</td>
+<td class="tg-0pky">
+1,135
+</td>
+<td class="tg-0pky">
+191
+</td>
+<td class="tg-0pky">
+16.8%
+</td>
+</tr>
+<tr>
+<td class="tg-0pky">
+Sacramento State
+</td>
+<td class="tg-0pky">
+1,229
+</td>
+<td class="tg-0pky">
+253
+</td>
+<td class="tg-0pky">
+20.1%
+</td>
+</tr>
+<tr>
+<td class="tg-0pky">
+San Francisco State
+</td>
+<td class="tg-0pky">
+2,743
+</td>
+<td class="tg-0pky">
+279
+</td>
+<td class="tg-0pky">
+10.2%
+</td>
+</tr>
+<tr>
+<td class="tg-0pky">
+UC Berkley
+</td>
+<td class="tg-0pky">
+600
+</td>
+<td class="tg-0pky">
+182
+</td>
+<td class="tg-0pky">
+30.3%
+</td>
+</tr>
+<tr>
+<td class="tg-0pky">
+<span style="font-weight:bold">Total</span>
+</td>
+<td class="tg-0pky">
+<span style="font-weight:bold">13,850</span>
+</td>
+<td class="tg-0pky">
+<span style="font-weight:bold">2,110</span>
+</td>
+<td class="tg-0pky">
+<span style="font-weight:bold">15.2%</span>
+</td>
+</tr>
+</tbody>
+</table>
+<p><br></p>
 <p><img src="automated_process.png" class="img-fluid"></p>
 <p><br></p>
 </section>


### PR DESCRIPTION
I added the table with the eop response rate. I used the `n` after removing responses because of missing data aka.  the `n` we use on the website. I'm realizing this probably makes less sense than keeping those responses when calculating the response rate. Should I make this change?